### PR TITLE
update documentation, clarify usage with multiple files, closes #382

### DIFF
--- a/docs/ilivalidator.rst
+++ b/docs/ilivalidator.rst
@@ -241,11 +241,19 @@ Aufruf-Syntax
 
 ``java -jar ilivalidator.jar [Options] [file]``
 
-``file`` kann auch die Form ``ilidata:DatesetId`` oder ``ilidata:BasketId`` haben, 
+``file`` kann mehrere Formen haben:
+
+- Dateipfad: Pfad zur lokal vorliegenden Transferdatei (.xtf/.itf) wie im 
+Fall 1 oben (``path/to/data.itf``)
+
+- Dataset: Angabe des Datensatzes mittels ``ilidata:DatesetId`` oder ``ilidata:BasketId``, 
 dann wird die entsprechende Datei aus den Repositories benutzt.
 
-``file`` kann auch die Form ``http:url`` oder ``https:url`` haben, 
+- Web-Resource: Angabe einer URL mittels ``http:url`` oder ``https:url``, 
 dann wird die entsprechende Datei heruntergeladen und benutzt.
+
+``file`` kann auch aus mehreren der oben genannten Einträgen bestehen. 
+Diese müssen durch ein Leerzeichen voneinander getrennt sein.
 
 Ohne Kommandozeilenargumente erscheint die Bildschirmmaske, mit deren Hilfe die zu validierende Datei 
 ausgewählt und die Validierung gestartet werden kann.

--- a/docs/ilivalidator.rst
+++ b/docs/ilivalidator.rst
@@ -243,17 +243,10 @@ Aufruf-Syntax
 
 ``file`` kann mehrere Formen haben:
 
-- Dateipfad: Pfad zur lokal vorliegenden Transferdatei (.xtf/.itf) wie im 
-Fall 1 oben (``path/to/data.itf``)
-
-- Dataset: Angabe des Datensatzes mittels ``ilidata:DatesetId`` oder ``ilidata:BasketId``, 
-dann wird die entsprechende Datei aus den Repositories benutzt.
-
-- Web-Resource: Angabe einer URL mittels ``http:url`` oder ``https:url``, 
-dann wird die entsprechende Datei heruntergeladen und benutzt.
-
-``file`` kann auch aus mehreren der oben genannten Einträgen bestehen. 
-Diese müssen durch ein Leerzeichen voneinander getrennt sein.
+- Dateipfad: Pfad zur lokal vorliegenden Transferdatei (.xtf/.itf) wie im Fall 1 oben (``path/to/data.itf``)
+- Dataset: Angabe des Datensatzes mittels ``ilidata:DatesetId`` oder ``ilidata:BasketId``, dann wird die entsprechende Datei aus den Repositories benutzt.
+- Web-Resource: Angabe einer URL mittels ``http:url`` oder ``https:url``, dann wird die entsprechende Datei heruntergeladen und benutzt.
+``file`` kann auch aus mehreren der oben genannten Einträgen bestehen. Diese müssen durch ein Leerzeichen voneinander getrennt sein.
 
 Ohne Kommandozeilenargumente erscheint die Bildschirmmaske, mit deren Hilfe die zu validierende Datei 
 ausgewählt und die Validierung gestartet werden kann.

--- a/docs/ilivalidator.rst
+++ b/docs/ilivalidator.rst
@@ -239,14 +239,12 @@ einzelner Anwendungsfälle beispielhaft im Kapitel „Funktionsweise“
 Aufruf-Syntax
 -------------
 
-``java -jar ilivalidator.jar [Options] [file]``
+``java -jar ilivalidator.jar [Options] [path...] [ilidata-URL...] [http-URL...]``
 
-``file`` kann mehrere Formen haben:
+- path: Pfad zu einer oder mehreren lokal vorliegenden Transferdateien (.xtf/.itf) wie im Fall 1 oben (``path/to/data.itf``)
+- ilidata-URL: Angabe von einem oder mehreren Datensätzen mittels ``ilidata:DatesetId`` oder ``ilidata:BasketId``. Es werden die entsprechenden Dateien aus den Repositories benutzt.
+- http-URL: Angabe von einer oder mehrerer URL mittels ``http:url`` oder ``https:url``. Es werden die entsprechenden Dateien heruntergeladen und benutzt.
 
-- Dateipfad: Pfad zur lokal vorliegenden Transferdatei (.xtf/.itf) wie im Fall 1 oben (``path/to/data.itf``)
-- Dataset: Angabe des Datensatzes mittels ``ilidata:DatesetId`` oder ``ilidata:BasketId``, dann wird die entsprechende Datei aus den Repositories benutzt.
-- Web-Resource: Angabe einer URL mittels ``http:url`` oder ``https:url``, dann wird die entsprechende Datei heruntergeladen und benutzt.
-``file`` kann auch aus mehreren der oben genannten Einträgen bestehen. Diese müssen durch ein Leerzeichen voneinander getrennt sein.
 
 Ohne Kommandozeilenargumente erscheint die Bildschirmmaske, mit deren Hilfe die zu validierende Datei 
 ausgewählt und die Validierung gestartet werden kann.


### PR DESCRIPTION
- add to documentation that multiple files can be simultaniously validated
- give `file` parameter a new structure in doc