### PR TITLE
fix table for metaConfig options

### DIFF
--- a/docs/ilivalidator.rst
+++ b/docs/ilivalidator.rst
@@ -525,7 +525,7 @@ In der Meta-Konfigurationsdatei werden die folgenden Parameter unterstützt (hie
 +---------------------------------+----------------------------------------------------+-----------------------------------------------------------------------------------+
 |                                 | .. code::                                          |                                                                                   |
 |                                 |                                                    |                                                                                   |
-| refmapping                      |   [ch.ehi.ilivalidator]                            | Entspricht dem Kommandozeilenargument ``--refmapping``                                |
+| refmapping                      |   [ch.ehi.ilivalidator]                            | Entspricht dem Kommandozeilenargument ``--refmapping``                            |
 |                                 |   refmapping=ilidata:DatesetId                     |                                                                                   |  
 |                                 |                                                    |                                                                                   |
 +---------------------------------+----------------------------------------------------+-----------------------------------------------------------------------------------+


### PR DESCRIPTION
Die Tabelle für die MetaConfig Optionen ist nicht sichtbar im gerenderten .rst, weil das abschliessende pipe-Zeichen für die Tabelle nicht korrekt ausgerichtet ist.