### PR TITLE
Treat empty strings as null

### DIFF
--- a/src/org/interlis2/validator/Main.java
+++ b/src/org/interlis2/validator/Main.java
@@ -399,7 +399,7 @@ public class Main {
 	  return null;
 	}
     public static String makeFileList(String[] xtfRefFile) {
-        if(xtfRefFile==null) {
+        if(xtfRefFile==null || xtfRefFile.length == 0) {
             return null;
         }
         StringBuffer files=new StringBuffer();


### PR DESCRIPTION
In `Validator.validate()` werden Settings aus MetaConfig und CLI via `MetaConfig.mergeSettings(src,dst)` zusammengeführt. Diese Merge-Funktion kopiert einen Wert aus `src` nur dann nach `dst`, wenn `dst.getValue(key) == null`.  